### PR TITLE
Add eslint rule for sorting of import members

### DIFF
--- a/src/plugin/eslint.ts
+++ b/src/plugin/eslint.ts
@@ -33,6 +33,12 @@ export const eslint = (): Plugin => ({
               'warnOnUnassignedImports': true,
             },
           ],
+          // 'import/order' does not care about the order of the members in an
+          // import statement. For that 'sort-imports' is needed:
+          'sort-imports': [
+            'error',
+            {ignoreDeclarationSort: true, ignoreMemberSort: false},
+          ],
           'no-shadow': 'error',
         },
       }),


### PR DESCRIPTION
`'import/order'` does not care about the order of the members in an import statement. For that `'sort-imports'` is needed.

---

Feel free to close this PR if you don't really care about the order of members in an import statement. I just noticed that the members in an import statement in aws-simple were not sorted, and therefore had a look into the eslint rules of onecmd.